### PR TITLE
Zeroing nanslices

### DIFF
--- a/zap/zap.py
+++ b/zap/zap.py
@@ -81,7 +81,7 @@ def process(cubefits, outcubefits='DATACUBE_ZAP.fits', clean=True,
             zlevel='median', cftype='median', cfwidthSVD=300, cfwidthSP=300,
             nevals=[], extSVD=None, skycubefits=None, mask=None,
             interactive=False, ncpu=None, pca_class=None, n_components=None,
-            overwrite=False, varcurvefits=None, zero_nan_slices=False):
+            overwrite=False, varcurvefits=None, zero_nan_slices=True):
     """ Performs the entire ZAP sky subtraction algorithm.
 
     This is the main ZAP function. It works on an input FITS file and
@@ -348,7 +348,7 @@ class Zap(object):
         NaNs have been set to zero 
     """
 
-    def __init__(self, cubefits, pca_class=None, n_components=None, zero_nan_slices=False):
+    def __init__(self, cubefits, pca_class=None, n_components=None, zero_nan_slices=True):
         self.cubefits = cubefits
         self.ins_mode = None
 


### PR DESCRIPTION
Fix #12

In some situations, we create MUSE cubes that have all NaN slices. This is particularly the case with fixed OUTPUT_WCS situations. This proposed change, adds a zero_nan_slices option to `process` and `Zap` which is set to True by default and which sets any slice that is filled with NaNs will be set to zeros. This is identical to how the laser gaps are treated. 

After cleaning the NaNs are reinserted, again just as for the laser gaps.

Do note that this is now _on_ by default - if not, these cubes are not possible to process so this does not really break any backwards compatability.
